### PR TITLE
Fix/v9token height

### DIFF
--- a/scripts/patches.js
+++ b/scripts/patches.js
@@ -46,13 +46,24 @@ export function Patch_Walls()
     game.currentTokenElevation = null;
     game.currentTokenHeight = 0;
     let currentTokenElevation=null; //for backwards compatability
+    function updateElevations(token) {
+        game.currentTokenElevation = (typeof _levels !== 'undefined') && _levels?.advancedLOS ? _levels.getTokenLOSheight(token) : token.data.elevation;
+        game.currentTokenHeight = game.settings.get(MODULE_ID,'enableTokenHeight') ? token.data.height * canvas.scene.data.gridDistance : 0
+        currentTokenElevation=game.currentTokenElevation;
+    }
+
     libWrapper.register(
         MODULE_ID, 'CONFIG.Token.objectClass.prototype.updateSource',function Patch_UpdateSource(wrapped,...args) {
             // store the token elevation in a common scope, so that it can be used by the following functions without needing to pass it explicitly
-            
-            game.currentTokenElevation = (typeof _levels !== 'undefined') && _levels?.advancedLOS ? _levels.getTokenLOSheight(this) : this.data.elevation;
-            game.currentTokenHeight = game.settings.get(MODULE_ID,'enableTokenHeight') ? this.data.height * canvas.scene.data.gridDistance : 0
-            currentTokenElevation=game.currentTokenElevation;
+            updateElevations(this)
+            wrapped(...args);
+    //        currentTokenElevation = null;
+        },'WRAPPER');
+
+    libWrapper.register(
+        MODULE_ID, 'CONFIG.Token.objectClass.prototype._onControl',function Patch_Token_onControl(wrapped,...args) {
+            // store the token elevation in a common scope, so that it can be used by the following functions without needing to pass it explicitly
+            updateElevations(this)
             wrapped(...args);
     //        currentTokenElevation = null;
         },'WRAPPER');

--- a/scripts/patches.js
+++ b/scripts/patches.js
@@ -63,7 +63,7 @@ export function Patch_Walls()
                 const {advancedVision,advancedMovement} = getSceneSettings(wall.scene);
                     if (
                         game.currentTokenElevation == null || !advancedVision ||
-                        (game.currentTokenElevation >= wallHeightBottom && game.currentTokenElevation < wallHeightTop)
+                        (game.currentTokenElevation >= wallHeightBottom && game.currentTokenElevation + game.currentTokenHeight < wallHeightTop)
                     ) {
                         return true
                     } else {


### PR DESCRIPTION
# Description
This update does the following for Foundry V9 compatibility:
- Registers a wrapper for Token `_onControl` events to recalculate token elevation/height when a new token is selected.
- Includes the token height in the Foundry V9 calculation when the option is enabled.

## Issues Closed
Closes #33 
Closes #34