### PR TITLE
Add helper functions to alleviate the mismatch between the module name and the incorrect flag scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,28 @@ With 3.5.2, the Set Elevation macro has been modified to support Multilevel Toke
 
 In addition, libWrapper support has been introduced to improve module compatability.
 
+## Helper Functions
+
+Due to the module beeing setup incorrectly and not wanting to break everyone's maps these helper functions can help you interact with Wall Height data since the regular getFlag\setFlag won't work
+
+```js
+WallHeight.getTop(wallPlaceableOrDocument)
+WallHeight.getBottom(wallPlaceableOrDocument)
+WallHeight.getWallBounds(wallPlaceableOrDocument)
+```
+will return the top and bottom of a wall placeable object or wall document (getWallBounds will return {top,bottom})
+
+```js
+WallHeight.setTop(wallDocument, top)
+WallHeight.setBottom(wallDocument, bottom)
+```
+will set the top\bottom of a wall document - these are both async
+
+```js
+WallHeight.updateAll(update, filter)
+```
+will mirror the canvas.walls.updateAll, the update object is {wallHeightTop,wallHeightBottom} - this is async
+
 ## Project Status
 
 Wall Height was originally released as a proof of concept to show that just a feature was possible by (cole#9640). I am now maintaining and adding to this modules and accepting feature requests.

--- a/scripts/wall-height.js
+++ b/scripts/wall-height.js
@@ -61,6 +61,39 @@ function registerSettings() {
         type: Boolean,
         default: false,
     });
+
+    globalThis.WallHeight = {
+      getTop: (wall) => {
+        return getWallBounds(wall).top;
+      },
+      getBottom: (wall) => {
+        return getWallBounds(wall).bottom;
+      },
+      getWallBounds: getWallBounds,
+      setTop: async (wallDocument, top) => {
+        const updateData = { flags: { wallHeight: {} } };
+        updateData.flags.wallHeight[TOP_KEY] = top;
+        return await wallDocument.update(updateData);
+      },
+      setBottom: async (wallDocument, bottom) => {
+        const updateData = { flags: { wallHeight: {} } };
+        updateData.flags.wallHeight[BOTTOM_KEY] = bottom;
+        return await wallDocument.update(updateData);
+      },
+      updateAll: async (update, filter) => {
+        const top = update[TOP_KEY];
+        const bottom = update[BOTTOM_KEY];
+        const updateData = {
+          flags: {
+            wallHeight: {},
+          },
+        };
+        if (top !== undefined) updateData.flags.wallHeight[TOP_KEY] = top;
+        if (bottom !== undefined)
+          updateData.flags.wallHeight[BOTTOM_KEY] = bottom;
+        return await canvas.walls.updateAll(updateData, filter);
+      },
+    };
 }
 
 Hooks.on("renderWallConfig", (app, html, data) => {


### PR DESCRIPTION
To avoid breaking everyone's maps while still providing functionality, these helper can act as substitute for the get\set flag methods